### PR TITLE
fix: shutdown action for live entity

### DIFF
--- a/core/src/main/kotlin/live/LiveGuild.kt
+++ b/core/src/main/kotlin/live/LiveGuild.kt
@@ -119,6 +119,10 @@ fun LiveGuild.onGuildCreate(block: suspend (GuildCreateEvent) -> Unit) = on(cons
 @KordPreview
 fun LiveGuild.onGuildUpdate(block: suspend (GuildUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveGuild.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveGuild.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 

--- a/core/src/main/kotlin/live/LiveKordEntity.kt
+++ b/core/src/main/kotlin/live/LiveKordEntity.kt
@@ -32,6 +32,9 @@ abstract class AbstractLiveKordEntity(dispatcher: CoroutineDispatcher) : LiveKor
 
     override val coroutineContext: CoroutineContext = dispatcher + SupervisorJob()
 
+    var shutdownAction: (() -> Unit)? = null
+    private set
+
     private val mutex = Mutex()
 
     @Suppress("EXPERIMENTAL_API_USAGE")
@@ -44,8 +47,13 @@ abstract class AbstractLiveKordEntity(dispatcher: CoroutineDispatcher) : LiveKor
     protected abstract fun filter(event: Event): Boolean
     protected abstract fun update(event: Event)
 
+    fun onShutDown(action: (() -> Unit)?){
+        shutdownAction = action
+    }
+
     override fun shutDown() {
-        cancel("Shutdown executed")
+        shutdownAction?.invoke()
+        cancel()
     }
 }
 

--- a/core/src/main/kotlin/live/LiveMember.kt
+++ b/core/src/main/kotlin/live/LiveMember.kt
@@ -25,9 +25,17 @@ fun LiveMember.onLeave(block: suspend (MemberLeaveEvent) -> Unit) = on(consumer 
 @KordPreview
 fun LiveMember.onUpdate(block: suspend (MemberUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveMember.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveMember.onBanAdd(block: suspend (BanAddEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the live entity is shutdown",
+    ReplaceWith("LiveMember.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 inline fun LiveGuildChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is MemberLeaveEvent || it is BanAddEvent || it is GuildDeleteEvent) {
@@ -35,6 +43,10 @@ inline fun LiveGuildChannel.onShutDown(crossinline block: suspend (Event) -> Uni
     }
 }
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveMember.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveGuildChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 

--- a/core/src/main/kotlin/live/LiveMessage.kt
+++ b/core/src/main/kotlin/live/LiveMessage.kt
@@ -59,6 +59,10 @@ fun LiveMessage.onCreate(block: suspend (MessageCreateEvent) -> Unit) = on(consu
 @KordPreview
 fun LiveMessage.onUpdate(block: suspend (MessageUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the live entity is shutdown",
+    ReplaceWith("LiveMessage.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 inline fun LiveMessage.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is MessageDeleteEvent || it is MessageBulkDeleteEvent
@@ -68,15 +72,31 @@ inline fun LiveMessage.onShutDown(crossinline block: suspend (Event) -> Unit) = 
     }
 }
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveMessage.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveMessage.onOnlyDelete(block: suspend (MessageDeleteEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveMessage.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveMessage.onBulkDelete(block: suspend (MessageBulkDeleteEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveMessage.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveMessage.onChannelDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveMessage.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveMessage.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 

--- a/core/src/main/kotlin/live/LiveRole.kt
+++ b/core/src/main/kotlin/live/LiveRole.kt
@@ -17,12 +17,20 @@ fun Role.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) = LiveRole(
 inline fun Role.live(dispatcher: CoroutineDispatcher = Dispatchers.Default, block: LiveRole.() -> Unit) =
     this.live(dispatcher).apply(block)
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveRole.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveRole.onDelete(block: suspend (RoleDeleteEvent) -> Unit) = on(consumer = block)
 
 @KordPreview
 fun LiveRole.onUpdate(block: suspend (RoleUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the live entity is shutdown",
+    ReplaceWith("LiveRole.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 inline fun LiveRole.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is RoleDeleteEvent || it is GuildDeleteEvent) {
@@ -30,6 +38,10 @@ inline fun LiveRole.onShutDown(crossinline block: suspend (Event) -> Unit) = on<
     }
 }
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveRole.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveRole.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 

--- a/core/src/main/kotlin/live/channel/LiveCategory.kt
+++ b/core/src/main/kotlin/live/channel/LiveCategory.kt
@@ -28,6 +28,10 @@ fun LiveCategory.onCreate(block: suspend (CategoryCreateEvent) -> Unit) = on(con
 @KordPreview
 fun LiveCategory.onUpdate(block: suspend (CategoryUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the live entity is shutdown",
+    ReplaceWith("LiveCategory.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 inline fun LiveCategory.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is CategoryDeleteEvent || it is GuildDeleteEvent) {
@@ -35,9 +39,17 @@ inline fun LiveCategory.onShutDown(crossinline block: suspend (Event) -> Unit) =
     }
 }
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveCategory.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveCategory.onDelete(block: suspend (CategoryDeleteEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveCategory.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveCategory.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 

--- a/core/src/main/kotlin/live/channel/LiveDmChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveDmChannel.kt
@@ -27,6 +27,10 @@ fun LiveDmChannel.onCreate(block: suspend (DMChannelCreateEvent) -> Unit) = on(c
 @KordPreview
 fun LiveDmChannel.onUpdate(block: suspend (DMChannelUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the live entity is shutdown",
+    ReplaceWith("LiveDmChannel.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 inline fun LiveDmChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is DMChannelDeleteEvent || it is GuildDeleteEvent) {
@@ -34,9 +38,17 @@ inline fun LiveDmChannel.onShutDown(crossinline block: suspend (Event) -> Unit) 
     }
 }
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveDmChannel.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveDmChannel.onDelete(block: suspend (DMChannelDeleteEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveDmChannel.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveDmChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 

--- a/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
@@ -29,6 +29,10 @@ fun LiveGuildChannel.onCreate(block: suspend (ChannelCreateEvent) -> Unit) = on(
 @KordPreview
 fun LiveGuildChannel.onUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the live entity is shutdown",
+    ReplaceWith("LiveGuildChannel.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 inline fun LiveGuildChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is ChannelDeleteEvent || it is GuildDeleteEvent) {
@@ -36,9 +40,17 @@ inline fun LiveGuildChannel.onShutDown(crossinline block: suspend (Event) -> Uni
     }
 }
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveGuildChannel.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveGuildChannel.onDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveGuildChannel.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveGuildChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 

--- a/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
@@ -28,6 +28,10 @@ fun LiveGuildMessageChannel.onCreate(block: suspend (ChannelCreateEvent) -> Unit
 @KordPreview
 fun LiveGuildMessageChannel.onUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the live entity is shutdown",
+    ReplaceWith("LiveGuildMessageChannel.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 inline fun LiveGuildMessageChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is ChannelDeleteEvent || it is GuildDeleteEvent) {
@@ -35,9 +39,17 @@ inline fun LiveGuildMessageChannel.onShutDown(crossinline block: suspend (Event)
     }
 }
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveGuildMessageChannel.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveGuildMessageChannel.onChannelDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveGuildMessageChannel.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveGuildMessageChannel.onDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 

--- a/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
@@ -28,6 +28,10 @@ fun LiveVoiceChannel.onCreate(block: suspend (VoiceChannelCreateEvent) -> Unit) 
 @KordPreview
 fun LiveVoiceChannel.onUpdate(block: suspend (VoiceChannelUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the live entity is shutdown",
+    ReplaceWith("LiveVoiceChannel.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 inline fun LiveVoiceChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is VoiceChannelDeleteEvent || it is GuildDeleteEvent) {
@@ -35,9 +39,17 @@ inline fun LiveVoiceChannel.onShutDown(crossinline block: suspend (Event) -> Uni
     }
 }
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveVoiceChannel.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveVoiceChannel.onDelete(block: suspend (VoiceChannelDeleteEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveVoiceChannel.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveVoiceChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 


### PR DESCRIPTION
Deprecate the listening where the live entity is shutdown because the methods are never called
Create a property to apply action when the entity is shutdown